### PR TITLE
Largest palindrome product

### DIFF
--- a/Task4.rb
+++ b/Task4.rb
@@ -1,0 +1,13 @@
+require 'benchmark'
+require 'bigdecimal/math'
+puts Benchmark.measure { BigMath.PI(10_000)
+arr = (100..999).to_a
+sum_arr = arr.inject([]) { |sum, elem| sum = sum + arr.map { |num| num * elem } }.select do
+|pol|
+  string = pol.to_s
+  pol = pol.to_s
+  pol == string.reverse
+end
+puts sum_arr.max
+}
+


### PR DESCRIPTION
A palindromic number reads the same both ways. The largest palindrome made from the product of two 2-digit numbers is 9009 = 91 × 99.

Find the largest palindrome made from the product of two 3-digit numbers.

**Benchmark:**
1.284332   0.860538   2.144870 (  2.145665)